### PR TITLE
Update @layout.latte - playground to datagrid-skeleton

### DIFF
--- a/app/templates/@layout.latte
+++ b/app/templates/@layout.latte
@@ -70,7 +70,7 @@
 			<h5 class="">
 				{var $reflection = new ReflectionClass($control)}
 				{var $presenterFile = basename($reflection->getFileName())}
-				<span class="fa fa-info"></span>&nbsp;&nbsp;See the code below 👇 or see <a href="https://github.com/contributte/playground/blob/master/contributte-datagrid/app/Presenters/{$presenterFile}" target="_blank">GitHub</a>
+				<span class="fa fa-info"></span>&nbsp;&nbsp;See the code below 👇 or see <a href="https://github.com/contributte/datagrid-skeleton/tree/master/app/Presenters/{$presenterFile}" target="_blank">GitHub</a>
 			</h5>
 
 			<pre><code class="language-php">{include 'datagridFactoryCode.latte', method => 'createComponentGrid'}</code></pre>


### PR DESCRIPTION
The URL of example datagrid GitHub repository has been changed from playground to datagrid-skeleton