### PR TITLE
Migrate Skeleton from Tailwind to Bootstrap 5 + Upgrade Tooling and Examples

### DIFF
--- a/app/UI/@Templates/@layout.latte
+++ b/app/UI/@Templates/@layout.latte
@@ -83,6 +83,9 @@
 				<div>
 					<a n:class="isLinkCurrent('Cdn:*') ? 'fw-bold', ''" n:href="Cdn:">CDN</a>
 				</div>
+				<div>
+					<a n:class="isLinkCurrent('NoPagination:*') ? 'fw-bold', ''" n:href="NoPagination:">No Pagination</a>
+				</div>
 			</div>
 		</div>
 		<div class="bg-white col-12 col-md">

--- a/app/UI/@Templates/@layout.latte
+++ b/app/UI/@Templates/@layout.latte
@@ -15,22 +15,19 @@
 		<link rel="stylesheet" type="text/css" href="{$basePath}/dist/app.css">
 		<script defer src="{$basePath}/dist/app.js"></script>
 	{/block}
-
-	<!-- Skeleton -->
-	<script src="https://unpkg.com/@tailwindcss/browser@4"></script>
 </head>
 
-<body class="!bg-zinc-100">
+<body class="bg-light">
 {snippet flashes}
-	<div class="w-full !mt-2">
-		<div class="mx-auto md:max-w-5xl">
+	<div class="container-fluid mt-2">
+		<div class="container">
 			<div
 					n:foreach="$flashes as $flash"
-					{if $flash->type === 'info'}class="bg-blue-100 p-2 rounded border !border-blue-600"
-					{elseif $flash->type === 'error'}class="bg-red-100 p-2 rounded border !border-red-600"
-					{elseif $flash->type === 'success'}class="bg-green-100 p-2 rounded border !border-green-600"
-					{elseif $flash->type === 'warning'}class="bg-yellow-100 p-2 rounded border !border-yellow-600"
-					{else}class="bg-gray-100 p-2 rounded border !border-gray-600"
+					{if $flash->type === 'info'}class="alert alert-info"
+					{elseif $flash->type === 'error'}class="alert alert-danger"
+					{elseif $flash->type === 'success'}class="alert alert-success"
+					{elseif $flash->type === 'warning'}class="alert alert-warning"
+					{else}class="alert alert-secondary"
 					{/if}
 			>
 				{$flash->message}
@@ -39,53 +36,56 @@
 	</div>
 {/snippet}
 
-<div class="md:max-w-7xl mx-auto mt-4">
-	<div class="grid grid-cols-[200px_auto] !gap-4 text-black">
-		<div class="!px-2 flex flex-col gap-2 divide-y divide-gray-300">
-			<div class="font-bold text-3xl">Datagrid</div>
-			<div class="grid grid-cols-1 !gap-2">
+<div class="container mt-4">
+	<div class="row g-4">
+		<div class="col-12 col-md-2">
+			<div class="fw-bold fs-3">Datagrid</div>
+			<div class="d-grid gap-2">
 				<div>
-					<a n:class="isLinkCurrent('Home:*') ? 'font-bold', ''" n:href="Home:">Home</a>
+					<a n:class="isLinkCurrent('Home:*') ? 'fw-bold', ''" n:href="Home:">Home</a>
 				</div>
 				<div>
-					<a n:class="isLinkCurrent('Filters:*') ? 'font-bold', ''" n:href="Filters:">Filters</a>
+					<a n:class="isLinkCurrent('Filters:*') ? 'fw-bold', ''" n:href="Filters:">Filters</a>
 				</div>
 				<div>
-					<a n:class="isLinkCurrent('Columns:*') ? 'font-bold', ''" n:href="Columns:">Columns</a>
+					<a n:class="isLinkCurrent('OuterFilters:*') ? 'fw-bold', ''" n:href="OuterFilters:">Outer Filters</a>
 				</div>
 				<div>
-					<a n:class="isLinkCurrent('Actions:*') ? 'font-bold', ''" n:href="Actions:">Actions</a>
+					<a n:class="isLinkCurrent('Columns:*') ? 'fw-bold', ''" n:href="Columns:">Columns</a>
 				</div>
 				<div>
-					<a n:class="isLinkCurrent('GroupActions:*') ? 'font-bold', ''" n:href="GroupActions:">Group Actions</a>
+					<a n:class="isLinkCurrent('Actions:*') ? 'fw-bold', ''" n:href="Actions:">Actions</a>
 				</div>
 				<div>
-					<a n:class="isLinkCurrent('Row:*') ? 'font-bold', ''" n:href="Row:">Row</a>
+					<a n:class="isLinkCurrent('GroupActions:*') ? 'fw-bold', ''" n:href="GroupActions:">Group Actions</a>
 				</div>
 				<div>
-					<a n:class="isLinkCurrent('ItemDetail:*') ? 'font-bold', ''" n:href="ItemDetail:">ItemDetail</a>
+					<a n:class="isLinkCurrent('Row:*') ? 'fw-bold', ''" n:href="Row:">Row</a>
 				</div>
 				<div>
-					<a n:class="isLinkCurrent('Export:*') ? 'font-bold', ''" n:href="Export:">Export</a>
+					<a n:class="isLinkCurrent('ItemDetail:*') ? 'fw-bold', ''" n:href="ItemDetail:">ItemDetail</a>
 				</div>
 				<div>
-					<a n:class="isLinkCurrent('TreeView:*') ? 'font-bold', ''" n:href="TreeView:">TreeView</a>
+					<a n:class="isLinkCurrent('Export:*') ? 'fw-bold', ''" n:href="Export:">Export</a>
 				</div>
 				<div>
-					<a n:class="isLinkCurrent('Edit:*') ? 'font-bold', ''" n:href="Edit:">Edit</a>
+					<a n:class="isLinkCurrent('TreeView:*') ? 'fw-bold', ''" n:href="TreeView:">TreeView</a>
 				</div>
 				<div>
-					<a n:class="isLinkCurrent('Add:*') ? 'font-bold', ''" n:href="Add:">Add</a>
+					<a n:class="isLinkCurrent('Edit:*') ? 'fw-bold', ''" n:href="Edit:">Edit</a>
 				</div>
 				<div>
-					<a n:class="isLinkCurrent('Localization:*') ? 'font-bold', ''" n:href="Localization:">Localization</a>
+					<a n:class="isLinkCurrent('Add:*') ? 'fw-bold', ''" n:href="Add:">Add</a>
 				</div>
 				<div>
-					<a n:class="isLinkCurrent('Cdn:*') ? 'font-bold', ''" n:href="Cdn:">CDN</a>
+					<a n:class="isLinkCurrent('Localization:*') ? 'fw-bold', ''" n:href="Localization:">Localization</a>
+				</div>
+				<div>
+					<a n:class="isLinkCurrent('Cdn:*') ? 'fw-bold', ''" n:href="Cdn:">CDN</a>
 				</div>
 			</div>
 		</div>
-		<div class="!bg-white !rounded !rounded-8">
+		<div class="bg-white col-12 col-md">
 			{include content}
 		</div>
 	</div>

--- a/app/UI/Cdn/CdnPresenter.php
+++ b/app/UI/Cdn/CdnPresenter.php
@@ -15,7 +15,7 @@ final class CdnPresenter extends AbstractPresenter
 	public function createComponentGrid(): Datagrid
 	{
 		$grid = new DataGrid();
-		$grid->setStrictSessionFilterValues(false);
+		$grid->setStrictStorageFilterValues(false);
 
 		$grid->setDataSource($this->dibiConnection->select('*')->from('users'));
 

--- a/app/UI/NoPagination/NoPaginationPresenter.php
+++ b/app/UI/NoPagination/NoPaginationPresenter.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types = 1);
+
+namespace App\UI\NoPagination;
+
+use App\Model\Utils\DateTime;
+use App\UI\AbstractPresenter;
+use Contributte\Datagrid\Datagrid;
+use Dibi\Fluent;
+use Dibi\Row;
+use Nette\Utils\ArrayHash;
+
+final class NoPaginationPresenter extends AbstractPresenter
+{
+
+	public function createComponentGrid(): Datagrid
+	{
+		$grid = new DataGrid();
+
+		$grid->setDataSource($this->dibiConnection->select('*')->from('users')->limit(20));
+
+		$grid->setPagination(false);
+
+		$grid->addColumnText('id', 'Id')
+			->setFilterText()
+			->setExactSearch();
+
+		$grid->addColumnText('name', 'Name')
+			->setFilterText();
+
+		$grid->addColumnStatus('status', 'Status')
+			->setFilterSelect([
+				'' => 'All',
+				'active' => 'Active',
+				'inactive' => 'Inactive',
+				'deleted' => 'Deleted',
+			]);
+
+		$grid->addColumnStatus('multistatus', 'Multi Status', 'status')
+			->setFilterMultiSelect([
+				'' => 'All',
+				'active' => 'Active',
+				'inactive' => 'Inactive',
+				'deleted' => 'Deleted',
+			]);
+
+		$grid->addColumnDateTime('birth_date', 'Birthday')
+			->setFormat('j. n. Y')
+			->setSortable()
+			->setFilterDate();
+
+		$grid->addColumnDateTime('birth_date_2', 'Birthday 2', 'birth_date')
+			->setFormat('j. n. Y')
+			->setSortable()
+			->setFilterDateRange();
+
+		$grid->addColumnNumber('age', 'Age')
+			->setRenderer(fn (Row $row): ?int => DateTime::fromSafe($row->asDateTime('birth_date'))?->diff(new DateTime())->y)
+			->setFilterRange()
+			->setCondition(function (Fluent $fluent, ArrayHash $values): void {
+				if ((bool) $values['from']) {
+					$fluent->where('(YEAR(CURDATE()) - YEAR(birth_date)) >= ?', $values['from']);
+				}
+
+				if ((bool) $values['to']) {
+					$fluent->where('(YEAR(CURDATE()) - YEAR(birth_date)) <= ?', $values['to']);
+				}
+			});
+
+		return $grid;
+	}
+
+}

--- a/app/UI/NoPagination/Templates/default.latte
+++ b/app/UI/NoPagination/Templates/default.latte
@@ -1,0 +1,3 @@
+{block content}
+	{control grid}
+{/block}

--- a/app/UI/OuterFilters/OuterFiltersPresenter.php
+++ b/app/UI/OuterFilters/OuterFiltersPresenter.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types = 1);
+
+namespace App\UI\OuterFilters;
+
+use App\Model\Utils\DateTime;
+use App\UI\AbstractPresenter;
+use Contributte\Datagrid\Datagrid;
+use Dibi\Fluent;
+use Dibi\Row;
+use Nette\Utils\ArrayHash;
+
+final class OuterFiltersPresenter extends AbstractPresenter
+{
+
+	public function createComponentGrid(): Datagrid
+	{
+		$grid = new DataGrid();
+
+		$grid->setOuterFilterRendering(true);
+
+		$grid->setDataSource($this->dibiConnection->select('*')->from('users'));
+
+		$grid->setItemsPerPageList([20, 50, 100], true);
+
+		$grid->addColumnText('id', 'Id')
+			->setFilterText()
+			->setExactSearch();
+
+		$grid->addColumnText('name', 'Name')
+			->setFilterText();
+
+		$grid->addColumnStatus('status', 'Status')
+			->setFilterSelect([
+				'' => 'All',
+				'active' => 'Active',
+				'inactive' => 'Inactive',
+				'deleted' => 'Deleted',
+			]);
+
+		$grid->addColumnStatus('multistatus', 'Multi Status', 'status')
+			->setFilterMultiSelect([
+				'' => 'All',
+				'active' => 'Active',
+				'inactive' => 'Inactive',
+				'deleted' => 'Deleted',
+			]);
+
+		$grid->addColumnDateTime('birth_date', 'Birthday')
+			->setFormat('j. n. Y')
+			->setSortable()
+			->setFilterDate();
+
+		$grid->addColumnDateTime('birth_date_2', 'Birthday 2', 'birth_date')
+			->setFormat('j. n. Y')
+			->setSortable()
+			->setFilterDateRange();
+
+		$grid->addColumnNumber('age', 'Age')
+			->setRenderer(fn (Row $row): ?int => DateTime::fromSafe($row->asDateTime('birth_date'))?->diff(new DateTime())->y)
+			->setFilterRange()
+			->setCondition(function (Fluent $fluent, ArrayHash $values): void {
+				if ((bool) $values['from']) {
+					$fluent->where('(YEAR(CURDATE()) - YEAR(birth_date)) >= ?', $values['from']);
+				}
+
+				if ((bool) $values['to']) {
+					$fluent->where('(YEAR(CURDATE()) - YEAR(birth_date)) <= ?', $values['to']);
+				}
+			});
+
+		return $grid;
+	}
+
+}

--- a/app/UI/OuterFilters/Templates/default.latte
+++ b/app/UI/OuterFilters/Templates/default.latte
@@ -1,0 +1,3 @@
+{block content}
+	{control grid}
+{/block}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3,6 +3,7 @@
 @import 'bootstrap/dist/css/bootstrap.css';
 @import 'vanillajs-datepicker/css/datepicker-bs5.css';
 @import "tom-select/dist/css/tom-select.css";
+@import "tom-select/dist/css/tom-select.bootstrap5.css";
 @import '../../vendor/ublaboo/datagrid/assets/css/happy.css';
 @import '../../vendor/ublaboo/datagrid/assets/css/datagrid.css';
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,1 @@
+/** Your CSS styles go here **/

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -21,9 +21,14 @@ import {
 import { NajaAjax } from "../../vendor/ublaboo/datagrid/assets/ajax";
 import Select from "tom-select";
 import { Dropdown } from "bootstrap";
+import Datepicker from 'vanillajs-datepicker/Datepicker';
+import cs from 'vanillajs-datepicker/locales/cs';
 
 // Styles
 import '../css/main.css';
+
+// Datepicker Locale
+Object.assign(Datepicker.locales, cs);
 
 // Datagrid + UI
 document.addEventListener("DOMContentLoaded", () => {
@@ -47,7 +52,7 @@ document.addEventListener("DOMContentLoaded", () => {
 				new NetteFormsPlugin(netteForms),
 				new HappyPlugin(new Happy()),
 				new SortablePlugin(new SortableJS()),
-				new DatepickerPlugin(new VanillaDatepicker({ buttonClass: 'btn' })),
+				new DatepickerPlugin(new VanillaDatepicker({ buttonClass: 'btn', language: 'cs' })),
 				new SelectpickerPlugin(new TomSelect(Select)),
 				new TreeViewPlugin(),
 			],

--- a/composer.lock
+++ b/composer.lock
@@ -2497,12 +2497,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/contributte/datagrid.git",
-                "reference": "1f061cb109cfa77f0918b327550fb2e9b8d85613"
+                "reference": "668ff520aa05dad5c3f39400e68552070e201820"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/contributte/datagrid/zipball/1f061cb109cfa77f0918b327550fb2e9b8d85613",
-                "reference": "1f061cb109cfa77f0918b327550fb2e9b8d85613",
+                "url": "https://api.github.com/repos/contributte/datagrid/zipball/668ff520aa05dad5c3f39400e68552070e201820",
+                "reference": "668ff520aa05dad5c3f39400e68552070e201820",
                 "shasum": ""
             },
             "require": {
@@ -2510,7 +2510,7 @@
                 "nette/di": "^3.0.0",
                 "nette/forms": "^3.2.0",
                 "nette/utils": "^4.0.0",
-                "php": ">=8.3",
+                "php": ">=8.2",
                 "symfony/property-access": "^6.4.0 || ^7.2.0"
             },
             "conflict": {
@@ -2584,7 +2584,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-06-11T13:59:44+00:00"
+            "time": "2025-06-30T12:57:31+00:00"
         }
     ],
     "packages-dev": [
@@ -3429,6 +3429,6 @@
     "platform": {
         "php": ">=8.3"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/config/local.neon.dist
+++ b/config/local.neon.dist
@@ -1,6 +1,6 @@
 # parameters:
 # 	db:
-# 		host: 0.0.0.0
+# 		host: database
 # 		username: contributte
 # 		password: contributte
 # 		database: contributte

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.7.2",
         "bootstrap": "^5.3.6",
-        "naja": "^2.6.1",
+        "naja": "^3.2.1",
         "nette-forms": "^3.5.3",
         "sortablejs": "^1.15.6",
         "tom-select": "^2.4.3",
@@ -1044,9 +1044,9 @@
       }
     },
     "node_modules/naja": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/naja/-/naja-2.6.1.tgz",
-      "integrity": "sha512-xLZPRJeOr6R3Zr5epRDSIzNzsb0RJ9T6LWhcNQbbarMLXQX+O26o1SEENsJ1NWFJfbJe1dWtv+iEiSShSHQZfA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/naja/-/naja-3.2.1.tgz",
+      "integrity": "sha512-Q2A9u7A4WA+pA/Nvsvq0hYk87wEULuPba0gj1IqEZ6JfJd7g0QHdiS+G6lBkY+CMzY2lM0V0E2zxwvpdBSyqBg==",
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/vanillajs-datepicker": "^1.3.5",
         "autoprefixer": "^10.4.21",
         "typescript": "^5.8.3",
-        "vite": "^6.3.5"
+        "vite": "^7.0.0"
       },
       "engines": {
         "node": ">=22.0",
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.41.1.tgz",
-      "integrity": "sha512-NELNvyEWZ6R9QMkiytB4/L4zSEaBC03KIXEghptLGLZWJ6VPrL63ooZQCOnlx36aQPGhzuOMwDerC1Eb2VmrLw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.44.1.tgz",
+      "integrity": "sha512-JAcBr1+fgqx20m7Fwe1DxPUl/hPkee6jA6Pl7n1v2EFiktAHenTaXl5aIFjUIEsfn9w3HE4gK1lEgNGMzBDs1w==",
       "cpu": [
         "arm"
       ],
@@ -507,9 +507,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.41.1.tgz",
-      "integrity": "sha512-DXdQe1BJ6TK47ukAoZLehRHhfKnKg9BjnQYUu9gzhI8Mwa1d2fzxA1aw2JixHVl403bwp1+/o/NhhHtxWJBgEA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.44.1.tgz",
+      "integrity": "sha512-RurZetXqTu4p+G0ChbnkwBuAtwAbIwJkycw1n6GvlGlBuS4u5qlr5opix8cBAYFJgaY05TWtM+LaoFggUmbZEQ==",
       "cpu": [
         "arm64"
       ],
@@ -521,9 +521,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.41.1.tgz",
-      "integrity": "sha512-5afxvwszzdulsU2w8JKWwY8/sJOLPzf0e1bFuvcW5h9zsEg+RQAojdW0ux2zyYAz7R8HvvzKCjLNJhVq965U7w==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.44.1.tgz",
+      "integrity": "sha512-fM/xPesi7g2M7chk37LOnmnSTHLG/v2ggWqKj3CCA1rMA4mm5KVBT1fNoswbo1JhPuNNZrVwpTvlCVggv8A2zg==",
       "cpu": [
         "arm64"
       ],
@@ -535,9 +535,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.41.1.tgz",
-      "integrity": "sha512-egpJACny8QOdHNNMZKf8xY0Is6gIMz+tuqXlusxquWu3F833DcMwmGM7WlvCO9sB3OsPjdC4U0wHw5FabzCGZg==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.44.1.tgz",
+      "integrity": "sha512-gDnWk57urJrkrHQ2WVx9TSVTH7lSlU7E3AFqiko+bgjlh78aJ88/3nycMax52VIVjIm3ObXnDL2H00e/xzoipw==",
       "cpu": [
         "x64"
       ],
@@ -549,9 +549,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.41.1.tgz",
-      "integrity": "sha512-DBVMZH5vbjgRk3r0OzgjS38z+atlupJ7xfKIDJdZZL6sM6wjfDNo64aowcLPKIx7LMQi8vybB56uh1Ftck/Atg==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.44.1.tgz",
+      "integrity": "sha512-wnFQmJ/zPThM5zEGcnDcCJeYJgtSLjh1d//WuHzhf6zT3Md1BvvhJnWoy+HECKu2bMxaIcfWiu3bJgx6z4g2XA==",
       "cpu": [
         "arm64"
       ],
@@ -563,9 +563,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.41.1.tgz",
-      "integrity": "sha512-3FkydeohozEskBxNWEIbPfOE0aqQgB6ttTkJ159uWOFn42VLyfAiyD9UK5mhu+ItWzft60DycIN1Xdgiy8o/SA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.44.1.tgz",
+      "integrity": "sha512-uBmIxoJ4493YATvU2c0upGz87f99e3wop7TJgOA/bXMFd2SvKCI7xkxY/5k50bv7J6dw1SXT4MQBQSLn8Bb/Uw==",
       "cpu": [
         "x64"
       ],
@@ -577,9 +577,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.41.1.tgz",
-      "integrity": "sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.44.1.tgz",
+      "integrity": "sha512-n0edDmSHlXFhrlmTK7XBuwKlG5MbS7yleS1cQ9nn4kIeW+dJH+ExqNgQ0RrFRew8Y+0V/x6C5IjsHrJmiHtkxQ==",
       "cpu": [
         "arm"
       ],
@@ -591,9 +591,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.41.1.tgz",
-      "integrity": "sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.44.1.tgz",
+      "integrity": "sha512-8WVUPy3FtAsKSpyk21kV52HCxB+me6YkbkFHATzC2Yd3yuqHwy2lbFL4alJOLXKljoRw08Zk8/xEj89cLQ/4Nw==",
       "cpu": [
         "arm"
       ],
@@ -605,9 +605,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.41.1.tgz",
-      "integrity": "sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.44.1.tgz",
+      "integrity": "sha512-yuktAOaeOgorWDeFJggjuCkMGeITfqvPgkIXhDqsfKX8J3jGyxdDZgBV/2kj/2DyPaLiX6bPdjJDTu9RB8lUPQ==",
       "cpu": [
         "arm64"
       ],
@@ -619,9 +619,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.41.1.tgz",
-      "integrity": "sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.44.1.tgz",
+      "integrity": "sha512-W+GBM4ifET1Plw8pdVaecwUgxmiH23CfAUj32u8knq0JPFyK4weRy6H7ooxYFD19YxBulL0Ktsflg5XS7+7u9g==",
       "cpu": [
         "arm64"
       ],
@@ -633,9 +633,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.41.1.tgz",
-      "integrity": "sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.44.1.tgz",
+      "integrity": "sha512-1zqnUEMWp9WrGVuVak6jWTl4fEtrVKfZY7CvcBmUUpxAJ7WcSowPSAWIKa/0o5mBL/Ij50SIf9tuirGx63Ovew==",
       "cpu": [
         "loong64"
       ],
@@ -647,9 +647,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.41.1.tgz",
-      "integrity": "sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.44.1.tgz",
+      "integrity": "sha512-Rl3JKaRu0LHIx7ExBAAnf0JcOQetQffaw34T8vLlg9b1IhzcBgaIdnvEbbsZq9uZp3uAH+JkHd20Nwn0h9zPjA==",
       "cpu": [
         "ppc64"
       ],
@@ -661,9 +661,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.41.1.tgz",
-      "integrity": "sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.44.1.tgz",
+      "integrity": "sha512-j5akelU3snyL6K3N/iX7otLBIl347fGwmd95U5gS/7z6T4ftK288jKq3A5lcFKcx7wwzb5rgNvAg3ZbV4BqUSw==",
       "cpu": [
         "riscv64"
       ],
@@ -675,9 +675,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.41.1.tgz",
-      "integrity": "sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.44.1.tgz",
+      "integrity": "sha512-ppn5llVGgrZw7yxbIm8TTvtj1EoPgYUAbfw0uDjIOzzoqlZlZrLJ/KuiE7uf5EpTpCTrNt1EdtzF0naMm0wGYg==",
       "cpu": [
         "riscv64"
       ],
@@ -689,9 +689,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.41.1.tgz",
-      "integrity": "sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.44.1.tgz",
+      "integrity": "sha512-Hu6hEdix0oxtUma99jSP7xbvjkUM/ycke/AQQ4EC5g7jNRLLIwjcNwaUy95ZKBJJwg1ZowsclNnjYqzN4zwkAw==",
       "cpu": [
         "s390x"
       ],
@@ -703,9 +703,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.41.1.tgz",
-      "integrity": "sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.44.1.tgz",
+      "integrity": "sha512-EtnsrmZGomz9WxK1bR5079zee3+7a+AdFlghyd6VbAjgRJDbTANJ9dcPIPAi76uG05micpEL+gPGmAKYTschQw==",
       "cpu": [
         "x64"
       ],
@@ -717,9 +717,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.41.1.tgz",
-      "integrity": "sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.44.1.tgz",
+      "integrity": "sha512-iAS4p+J1az6Usn0f8xhgL4PaU878KEtutP4hqw52I4IO6AGoyOkHCxcc4bqufv1tQLdDWFx8lR9YlwxKuv3/3g==",
       "cpu": [
         "x64"
       ],
@@ -731,9 +731,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.41.1.tgz",
-      "integrity": "sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.44.1.tgz",
+      "integrity": "sha512-NtSJVKcXwcqozOl+FwI41OH3OApDyLk3kqTJgx8+gp6On9ZEt5mYhIsKNPGuaZr3p9T6NWPKGU/03Vw4CNU9qg==",
       "cpu": [
         "arm64"
       ],
@@ -745,9 +745,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.41.1.tgz",
-      "integrity": "sha512-+psFT9+pIh2iuGsxFYYa/LhS5MFKmuivRsx9iPJWNSGbh2XVEjk90fmpUEjCnILPEPJnikAU6SFDiEUyOv90Pg==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.44.1.tgz",
+      "integrity": "sha512-JYA3qvCOLXSsnTR3oiyGws1Dm0YTuxAAeaYGVlGpUsHqloPcFjPg+X0Fj2qODGLNwQOAcCiQmHub/V007kiH5A==",
       "cpu": [
         "ia32"
       ],
@@ -759,9 +759,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.41.1.tgz",
-      "integrity": "sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.1.tgz",
+      "integrity": "sha512-J8o22LuF0kTe7m+8PvW9wk3/bRq5+mRo5Dqo6+vXb7otCm3TPhYOJqOaQtGU9YMWQSL3krMnoOxMr0+9E6F3Ug==",
       "cpu": [
         "x64"
       ],
@@ -783,9 +783,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -869,9 +869,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
-      "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.7.tgz",
+      "integrity": "sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==",
       "funding": [
         {
           "type": "github",
@@ -888,9 +888,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
-      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
       "dev": true,
       "funding": [
         {
@@ -908,8 +908,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001718",
-        "electron-to-chromium": "^1.5.160",
+        "caniuse-lite": "^1.0.30001726",
+        "electron-to-chromium": "^1.5.173",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -921,9 +921,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001720",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001720.tgz",
-      "integrity": "sha512-Ec/2yV2nNPwb4DnTANEV99ZWwm3ZWfdlfkQbWSDDt+PsXEVYwlhPH8tdMaPunYTKKmz7AnHi2oNEi1GcmKCD8g==",
+      "version": "1.0.30001726",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
+      "integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
       "dev": true,
       "funding": [
         {
@@ -942,9 +942,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.161",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.161.tgz",
-      "integrity": "sha512-hwtetwfKNZo/UlwHIVBlKZVdy7o8bIZxxKs0Mv/ROPiQQQmDgdm5a+KvKtBsxM8ZjFzTaCeLoodZ8jiBE3o9rA==",
+      "version": "1.5.177",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.177.tgz",
+      "integrity": "sha512-7EH2G59nLsEMj97fpDuvVcYi6lwTcM1xuWw3PssD8xzboAW7zj7iB3COEEEATUfjLHrs5uKBLQT03V/8URx06g==",
       "dev": true,
       "license": "ISC"
     },
@@ -1000,9 +1000,9 @@
       }
     },
     "node_modules/fdir": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
-      "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -1112,9 +1112,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "funding": [
         {
@@ -1148,13 +1148,13 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.41.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.41.1.tgz",
-      "integrity": "sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==",
+      "version": "4.44.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.44.1.tgz",
+      "integrity": "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.7"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -1164,26 +1164,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.41.1",
-        "@rollup/rollup-android-arm64": "4.41.1",
-        "@rollup/rollup-darwin-arm64": "4.41.1",
-        "@rollup/rollup-darwin-x64": "4.41.1",
-        "@rollup/rollup-freebsd-arm64": "4.41.1",
-        "@rollup/rollup-freebsd-x64": "4.41.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.41.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.41.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.41.1",
-        "@rollup/rollup-linux-arm64-musl": "4.41.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.41.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.41.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.41.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.41.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.41.1",
-        "@rollup/rollup-linux-x64-gnu": "4.41.1",
-        "@rollup/rollup-linux-x64-musl": "4.41.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.41.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.41.1",
-        "@rollup/rollup-win32-x64-msvc": "4.41.1",
+        "@rollup/rollup-android-arm-eabi": "4.44.1",
+        "@rollup/rollup-android-arm64": "4.44.1",
+        "@rollup/rollup-darwin-arm64": "4.44.1",
+        "@rollup/rollup-darwin-x64": "4.44.1",
+        "@rollup/rollup-freebsd-arm64": "4.44.1",
+        "@rollup/rollup-freebsd-x64": "4.44.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.44.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.44.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.44.1",
+        "@rollup/rollup-linux-arm64-musl": "4.44.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.44.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.44.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.44.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.44.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.44.1",
+        "@rollup/rollup-linux-x64-gnu": "4.44.1",
+        "@rollup/rollup-linux-x64-musl": "4.44.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.44.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.44.1",
+        "@rollup/rollup-win32-x64-msvc": "4.44.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -1289,24 +1289,24 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.0.0.tgz",
+      "integrity": "sha512-ixXJB1YRgDIw2OszKQS9WxGHKwLdCsbQNkpJN171udl6szi/rIySHL6/Os3s2+oE4P/FLD4dxg4mD7Wust+u5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
+        "fdir": "^6.4.6",
         "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
+        "postcss": "^8.5.6",
+        "rollup": "^4.40.0",
+        "tinyglobby": "^0.2.14"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -1315,14 +1315,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
         "jiti": ">=1.21.0",
-        "less": "*",
+        "less": "^4.0.0",
         "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.7.2",
     "bootstrap": "^5.3.6",
-    "naja": "^2.6.1",
+    "naja": "^3.2.1",
     "nette-forms": "^3.5.3",
     "sortablejs": "^1.15.6",
     "tom-select": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/vanillajs-datepicker": "^1.3.5",
     "autoprefixer": "^10.4.21",
     "typescript": "^5.8.3",
-    "vite": "^6.3.5"
+    "vite": "^7.0.0"
   },
   "scripts": {
     "watch": "vite build --watch --mode=development",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2018",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": [
       "ESNext",
       "ESNext.AsyncIterable",


### PR DESCRIPTION
This PR includes a major UI framework migration and other enhancements:
	•	Replaced Tailwind CSS with Bootstrap 5 throughout the skeleton
	•	Updated all layout and flash message styles to use Bootstrap classes
	•	Integrated Bootstrap 5-compatible Tom Select styles
	•	Switched from Naja 2 to Naja 3
	•	Upgraded Vite to version 7
	•	Improved local.neon.dist config for Docker compatibility
	•	Added new examples:
	  •	Outer Filters
	  •	No Pagination
	  •	Datepicker Language support
	•	Minor code consistency improvements (setStrictSessionFilterValues typo fix)